### PR TITLE
Make the fix for #591 even more focused

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/jquery_post.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_post.js
@@ -1,1 +1,1 @@
-var djdt = {jQuery: jQuery.noConflict(true)}; window.define = _djdt_define_backup;
+var djdt = {jQuery: jQuery.noConflict(true)}; window.define.amd = _djdt_define_backup;

--- a/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
@@ -1,1 +1,1 @@
-var _djdt_define_backup = window.define; window.define = undefined;
+var _djdt_define_backup = window.define.amd; window.define.amd = undefined;


### PR DESCRIPTION
When we undefine the entire window.define, modules loaded asynchronously
can randomly fail to register themselves. However, jQuery 2+ checks for
define.amd before registering itself as an AMD module, not just define.
So, by unsetting window.define.amd instead of window.define, we don't
break define() for other modules and we still prevent the page-global
jQuery from registering itself as an AMD module, which was the ultimate
goal of #591.