### PR TITLE
Better name for the define.amd backup

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/jquery_post.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_post.js
@@ -1,1 +1,1 @@
-var djdt = {jQuery: jQuery.noConflict(true)}; window.define.amd = _djdt_define_backup;
+var djdt = {jQuery: jQuery.noConflict(true)}; window.define.amd = _djdt_define_amd_backup;

--- a/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
@@ -1,1 +1,1 @@
-var _djdt_define_backup = window.define.amd; window.define.amd = undefined;
+var _djdt_define_amd_backup = window.define.amd; window.define.amd = undefined;


### PR DESCRIPTION
Rename the `define.amd` backup, per suggestion.